### PR TITLE
Add Rock definitions for the Multus thin CNI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update packages
+        run: sudo apt-get update
+
+      - name: Install docker
+        run: sudo snap install docker
+
+      - name: Initialize LXD
+        run: |
+          sudo lxd init --auto
+
+          sudo iptables -P FORWARD ACCEPT
+          sudo sysctl net.ipv4.ip_forward=1
+
+      - name: Install rockcraft
+        run: sudo snap install rockcraft --classic
+
+      - name: Install yq
+        run: sudo snap install yq
+
+      - name: Install tox
+        run: sudo apt-get install -y tox
+
+      - name: Run Tox (v3.8)
+        run: sudo tox -c v3.8/tox.ini
+
+      - name: Run Tox (v4.0.2)
+        run: sudo tox -c v4.0.2/tox.ini

--- a/v3.8/rockcraft.yaml
+++ b/v3.8/rockcraft.yaml
@@ -1,0 +1,41 @@
+name: multus
+summary: Rock for the Multus thin CNI.
+description: >
+  This rock is a drop in replacement for the
+  ghcr.io/k8snetworkplumbingwg/multus-cni thin image.
+version: v3.8
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+services:
+  multus:
+    command: /entrypoint.sh
+    override: replace
+    startup: enabled
+
+parts:
+  build-deps:
+    plugin: nil
+    build-snaps:
+      - go/1.21/stable
+
+  multus:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/k8snetworkplumbingwg/multus-cni
+    source-tag: v3.8
+    source-depth: 1
+    override-build: |
+      ./hack/build-go.sh
+
+      cp ./images/entrypoint.sh $CRAFT_PART_INSTALL
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/src/multus-cni
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL/usr/src/multus-cni
+      cp $CRAFT_PART_BUILD/LICENSE $CRAFT_PART_INSTALL/usr/src/multus-cni

--- a/v3.8/tests/test_rock.py
+++ b/v3.8/tests/test_rock.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+def check_image_paths(image, paths):
+    for path in paths:
+        subprocess.run(
+            [
+                "docker", "run", image,
+                "ls", "-l", path
+            ],
+            check=True,
+        )
+
+
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # check rock filesystem
+    check_image_paths(
+        LOCAL_ROCK_IMAGE,
+        [
+            "/entrypoint.sh",
+            "/usr/src/multus-cni/bin/multus",
+            "/usr/src/multus-cni/LICENSE",
+        ])

--- a/v3.8/tox.ini
+++ b/v3.8/tox.ini
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack -v
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export already packed rock to docker
+    bash -c 'NAME="$(yq -r .name rockcraft.yaml)" && \
+             VERSION="$(yq -r .version rockcraft.yaml)" && \
+             ARCH="$(yq -r ".platforms | keys | .[0]" rockcraft.yaml)" && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy \
+                oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+allowlist_externals =
+    echo
+commands =
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests

--- a/v4.0.2/rockcraft.yaml
+++ b/v4.0.2/rockcraft.yaml
@@ -1,0 +1,52 @@
+name: multus
+summary: Rock for the Multus thin CNI.
+description: >
+  This rock is a drop in replacement for the
+  ghcr.io/k8snetworkplumbingwg/multus-cni thin image.
+version: v4.0.2
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+services:
+  multus:
+    command: /thin_entrypoint
+    override: replace
+    startup: enabled
+
+parts:
+  build-deps:
+    plugin: nil
+    build-snaps:
+      - go/1.21/stable
+
+  multus:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/k8snetworkplumbingwg/multus-cni
+    source-tag: v4.0.2
+    source-depth: 1
+    override-build: |
+      ./hack/build-go.sh
+
+      cp $CRAFT_PART_BUILD/bin/install_multus $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_BUILD/bin/thin_entrypoint $CRAFT_PART_INSTALL
+      cp $CRAFT_PART_BUILD/LICENSE $CRAFT_PART_INSTALL
+
+      # NOTE: The upstream Dockerfile handpicks a few executables and adds them
+      # to the root dir, but also copies the entire bin folder to /usr/src/multus-cni.
+      # https://github.com/k8snetworkplumbingwg/multus-cni/blob/f03765681fe81ee1e0633ee1734bf48ab3bccf2b/images/Dockerfile#L13-L18
+      #
+      # This seems redundant, we end up with multiple copies of the same files.
+      # Furthermore, multus-shim, multus-daemon (and possibly the multus binary)
+      # should only be included in the "-thick" image flavor.
+      #
+      # We need this image to be a drop in replacement, so we'll preserve these files.
+      mkdir -p $CRAFT_PART_INSTALL/usr/src/multus-cni
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL/usr/src/multus-cni
+      cp $CRAFT_PART_BUILD/LICENSE $CRAFT_PART_INSTALL/usr/src/multus-cni

--- a/v4.0.2/tests/test_rock.py
+++ b/v4.0.2/tests/test_rock.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+def check_image_paths(image, paths):
+    for path in paths:
+        subprocess.run(
+            [
+                "docker", "run", image,
+                "ls", "-l", path
+            ],
+            check=True,
+        )
+
+
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # check rock filesystem
+    check_image_paths(
+        LOCAL_ROCK_IMAGE,
+        [
+            "/install_multus",
+            "/thin_entrypoint",
+            "/usr/src/multus-cni/LICENSE",
+            "/usr/src/multus-cni/bin/install_multus",
+            "/usr/src/multus-cni/bin/thin_entrypoint",
+            "/usr/src/multus-cni/bin/multus",
+            "/usr/src/multus-cni/bin/multus-daemon",
+            "/usr/src/multus-cni/bin/multus-shim",
+        ])

--- a/v4.0.2/tox.ini
+++ b/v4.0.2/tox.ini
@@ -1,0 +1,46 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack -v
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export already packed rock to docker
+    bash -c 'NAME="$(yq -r .name rockcraft.yaml)" && \
+             VERSION="$(yq -r .version rockcraft.yaml)" && \
+             ARCH="$(yq -r ".platforms | keys | .[0]" rockcraft.yaml)" && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy \
+                oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+allowlist_externals =
+    echo
+commands =
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests


### PR DESCRIPTION
We're defining rock images for the Multus CNI (thin plugin version). Based on https://github.com/k8snetworkplumbingwg/multus-cni/tree/master/images.

There is one subfolder for each covered version: v3.9 and v4.0.2.

At the same time, .github/workflows/tests.yaml is running some smoke tests which ensure that the images contain the expected files.