### PR TITLE
Changes v4.0.2 rock base to bare

### DIFF
--- a/tests/integration/test_multus_v3_8.py
+++ b/tests/integration/test_multus_v3_8.py
@@ -41,3 +41,20 @@ def test_multus_deployment(tmp_path: pathlib.Path, module_instance: harness.Inst
     k8s_util.wait_for_daemonset(
         module_instance, f"{INSTALL_NAME}-multus-ds", constants.K8S_NS_KUBE_SYSTEM
     )
+
+    # Sanity check: make sure there isn't an error in Pebble that it couldn't start the service.
+    process = module_instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "logs",
+            "-n",
+            constants.K8S_NS_KUBE_SYSTEM,
+            f"daemonset.apps/{INSTALL_NAME}-multus-ds",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert '(Start service "multus") failed' not in process.stdout

--- a/tests/integration/test_multus_v4_0_2.py
+++ b/tests/integration/test_multus_v4_0_2.py
@@ -36,3 +36,20 @@ def test_multus_deployment(module_instance: harness.Instance):
     k8s_util.wait_for_daemonset(
         module_instance, INSTALL_NAME, constants.K8S_NS_KUBE_SYSTEM
     )
+
+    # Sanity check: make sure there isn't an error in Pebble that it couldn't start the service.
+    process = module_instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "logs",
+            "-n",
+            constants.K8S_NS_KUBE_SYSTEM,
+            f"daemonset.apps/{INSTALL_NAME}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert '(Start service "multus") failed' not in process.stdout

--- a/tests/sanity/test_multus.py
+++ b/tests/sanity/test_multus.py
@@ -55,4 +55,4 @@ def test_multus_4_0_2():
     assert V4_0_2_EXPECTED_HELPSTR in docker_run.stderr
 
     # check rock filesystem
-    docker_util.ensure_image_contains_paths(rock.image, V4_0_2_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(rock.image, V4_0_2_EXPECTED_FILES)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -43,8 +43,10 @@ commands =
 description = Run integration tests
 deps =
     -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \

--- a/v4.0.2/rockcraft.yaml
+++ b/v4.0.2/rockcraft.yaml
@@ -6,7 +6,7 @@ description: >
 version: v4.0.2
 license: Apache-2.0
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 platforms:
   amd64:
@@ -31,6 +31,10 @@ parts:
     source: https://github.com/k8snetworkplumbingwg/multus-cni
     source-tag: v4.0.2
     source-depth: 1
+    stage-packages:
+      - coreutils
+      # Needed for pgrep, which is used as a liveness / readiness probe.
+      - procps
     override-build: |
       ./hack/build-go.sh
 


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

Only v4.0.2 is switched to bare as it is significantly simpler to achieve. It does require ``coreutils`` and ``procps`` (readiness probe uses ``pgrep``).

We can no longer use ensure_image_contains_paths to check if files exist in the rock images, since they are now bare-based. Instead, we can use ensure_image_contains_paths_bare, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.

Adds an extra sanity check during the integration tests, making sure that there is no error reported in Pebble while starting the service.